### PR TITLE
Handle 416 errors (server does not know how to handle Partial content).

### DIFF
--- a/lalita/plugins/url.py
+++ b/lalita/plugins/url.py
@@ -378,6 +378,11 @@ class Url (Plugin):
         if str (failure.value).startswith ('206'):
             # this is not a failure, but a response to a '206 partial content'
             return self.guessFile (failure.value.response, user, channel, url, date, time)
+        elif str (failure.value).startswith ('416'):
+            # this is not an error either, it's just that the stupid web server
+            # does not know how to do range requets
+            # try again
+            self.getPage (url, user, channel, date, time)
         else:
             self.say(channel, u"%s: error con la página: %s" % (user, failure.value))
             return url, False, failure.value

--- a/lalita/plugins/url.py
+++ b/lalita/plugins/url.py
@@ -8,7 +8,7 @@ import os
 import re
 import urlparse
 
-from twisted.web import client
+from twisted.web import client as web_client
 from twisted.internet import defer, reactor
 from twisted.python import failure
 
@@ -191,7 +191,7 @@ class Url (Plugin):
                 url = _sanitize(url)
                 if url is None:
                     return
-                promise= client.getPage (str (url), headers=dict (
+                promise= web_client.getPage (str (url), headers=dict (
                     Range='bytes=1-%d' % self.config['block_size'])
                     )
                 promise.addCallback (self.guessFile, user, channel, url, date, time)


### PR DESCRIPTION
Some servers do not seem to know what to do when a `Range` header is used, and they return a `416` status. In such a case we retry without the header, but this means that it would retrieve the whole page. Next step would be to cancel the fetch once we found it's a HTML page and we found the `<title>`.
